### PR TITLE
fix: start at index 1 for rendering ordered lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ md.list(["Item 1", "Item 2", "Item 3"]);
 // => "- Item 1\n- Item 2\n- Item 3"
 ```
 
+```js
+md.list(["Item 1", "Item 2", "Item 3"], { ordered: true });
+// => "1. Item 1\n2. Item 2\n3. Item 3")
+```
+
 #### `strikethrough(text)`
 
 Render a markdown strikethrough text.

--- a/src/render.ts
+++ b/src/render.ts
@@ -81,6 +81,7 @@ export function image(
  * Format a string as a code block.
  *
  * @example
+ *
  * ```js
  * md.codeBlock('console.log("Hello, World!");', 'js');
  * // => "```js\nconsole.log("Hello, World!");\n```"
@@ -105,6 +106,7 @@ export function codeBlock(
  * Render a markdown table.
  *
  * @example
+ *
  * ```js
  * md.table({
  *  columns: ["Breed", "Origin", "Size", "Temperament"],
@@ -208,6 +210,7 @@ export function blockquote(text: string): string {
  * Render a markdown strikethrough text.
  *
  * @example
+ *
  * ```js
  * md.strikethrough('Hello, World!');
  * // => "~~Hello, World!~~"
@@ -226,6 +229,7 @@ export function strikethrough(text: string): string {
  * Render a markdown horizontal rule.
  *
  * @example
+ *
  * ```js
  * md.hr();
  * // => "---"
@@ -244,9 +248,15 @@ export function hr(length = 3): string {
  * Render a markdown ordered or unordered list.
  *
  * @example
+ *
  * ```js
  * md.list(['Item 1', 'Item 2', 'Item 3']);
  * // => "- Item 1\n- Item 2\n- Item 3"
+ * ```
+ *
+ * ```js
+ * md.list(["Item 1", "Item 2", "Item 3"], { ordered: true });
+ * // => "1. Item 1\n2. Item 2\n3. Item 3")
  * ```
  *
  * @param items
@@ -262,7 +272,7 @@ export function list(
   return items
     .map(
       (item, index) =>
-        `${opts.ordered ? `${index}.` : opts.char || "-"} ${item}`,
+        `${opts.ordered ? `${index + 1}.` : opts.char || "-"} ${item}`,
     )
     .join("\n");
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a JSDoc example for enabling ordered lists, fixes the logic of the render function for lists to start at index 1 in ordered mode.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
